### PR TITLE
change Cargo.toml license to AGPL to match Spacedrive's

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Darren Schroeder"]
 edition = "2021"
 repository = "https://github.com/fdncred/nu_plugin_file"
 description = "a nushell plugin called file"
-license = "MIT"
+license = "AGPL-3.0-only"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The license file was updated, but Cargo.toml still reported the old license.