### PR TITLE
Depend on published/stable nu-* deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,9 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4640556d6abc057dab7001bf5612f6b9b144ce739bfa0669d66fbf1ef7ad28"
 dependencies = [
  "convert_case",
  "proc-macro-error",
@@ -863,7 +865,9 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa524164c6d87d9ce4dd1122525a539f92a77f4fbb6494452976cc2fa691742d"
 dependencies = [
  "log",
  "nu-glob",
@@ -875,11 +879,15 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4097b0014c26a039018990a4fe8d8fd5658c00e94621b34751869649b0aa942"
 
 [[package]]
 name = "nu-path"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b4a7d68a196e55c8e2c8685293bc1c17e9c13aa7dac5bcbe04a2a841e92770"
 dependencies = [
  "dirs",
  "omnipath",
@@ -888,7 +896,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6b2c69b4b0963fa2d1312a5df115a35b0f523e54b95d013eec87791806ff11d"
 dependencies = [
  "log",
  "nix",
@@ -902,7 +912,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dddcc6ef62272eedaa18f7f004090781969b99c29d4973a4dac6e4ce4395097"
 dependencies = [
  "interprocess",
  "log",
@@ -916,7 +928,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2716cc05722738406c1714c9788969dd10d75a3d4eddbf86b3ad423df1a5d74a"
 dependencies = [
  "bincode",
  "nu-protocol",
@@ -928,11 +942,12 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ae5262aabe662ac1cc02a6e8d3fdb48fa8bb25c77be72d2e8a625a7c3e4812"
 dependencies = [
  "brotli",
  "byte-unit",
- "bytes",
  "chrono",
  "chrono-humanize",
  "convert_case",
@@ -959,7 +974,9 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ed001bb4cb39b4235871cb00650b79497084fc46beaf019d226239119d3ef5"
 dependencies = [
  "chrono",
  "itertools 0.12.0",
@@ -977,7 +994,9 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.97.2"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d91a233afaa875d01784c898f4464755cbefb5eaf8845032d651e39ac6354f"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -992,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_file"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "goblin",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,8 @@ license = "AGPL-3.0-only"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# for local development, you can use a path dependency
-nu-plugin = { path = "../nushell/crates/nu-plugin", version = "0.97.2" }
-nu-protocol = { path = "../nushell/crates/nu-protocol", version = "0.97.2" }
-# nu-plugin = "0.95.0"
-# nu-protocol = "0.95.0"
+nu-plugin = "0.97.1"
+nu-protocol = "0.97.1"
 
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.125"

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ impl SimplePluginCommand for Implementation {
         "file"
     }
 
-    fn description(&self) -> &str {
+    fn usage(&self) -> &str {
         "View file format information"
     }
 


### PR DESCRIPTION
Depend on published crates only and rename `SimplePluginCommand::description` back to `usage`

This enables the `cargo install --git` flow directly from the repository and lifts the requirement to have local checkout of the nushell source